### PR TITLE
Add Artifact Registry support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -149,6 +149,8 @@ lazy val core = myCrossProject("core")
       Dependencies.refined,
       Dependencies.scalacacheCaffeine,
       Dependencies.tomlj,
+      // for artifact registry support
+      "dev.rolang" %% "gar-coursier" % "0.1.3",
       Dependencies.logbackClassic % Runtime,
       Dependencies.catsLaws % Test,
       Dependencies.circeLiteral % Test,


### PR DESCRIPTION
Credentials have to be passed to scala steward in order to authenticate to AR, like this:
```
export GOOGLE_APPLICATION_CREDENTIALS=/path/to/artifact-registry-credentials.json
```